### PR TITLE
Cleanup and Reduce memory use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
 target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
-release.properties
-dependency-reduced-pom.xml
-buildNumber.properties
-.mvn/timing.properties
+*.iml
+.idea/

--- a/LGPL2.1-template.txt
+++ b/LGPL2.1-template.txt
@@ -1,0 +1,17 @@
+${project.name}
+${project.description}
+Copyright (C) ${project.inceptionYear} ${organization}
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation; either version 2.1
+of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this library; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,504 @@
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -13,15 +13,21 @@
 
 	<artifactId>crypto</artifactId>
 	<version>0.4-SNAPSHOT</version>
-	<name>eXist wrapper for EXPath Cryptographic library</name>
-	<url>http://expath.org</url>
+
+	<name>eXist-db EXPath Cryptographic library</name>
+	<description>eXist-db wrapper for EXPath Cryptographic Java library</description>
+	<url>http://expath.org/spec/crypto</url>
+	<inceptionYear>2016</inceptionYear>
 
 	<properties>
-		<java-package-name>crypto</java-package-name>
+		<crypto.java.lib.version>1.4-SNAPSHOT</crypto.java.lib.version>
+
+		<crypto.module.namespace>http://expath.org/ns/${project.artifactId}</crypto.module.namespace>
+		<java-package-name>org.expath.exist.crypto</java-package-name>
 		<java-package-main-class-name>ExistExpathCryptoModule</java-package-main-class-name>
 		<module-prefix>${java-package-name}</module-prefix>
 		<package-title>EXPath Cryptographic Module Implementation</package-title>
-		<package-name>http://expath.org/ns/${project.artifactId}</package-name>
+		<package-name>${crypto.module.namespace}</package-name>
 		<package-abbrev>expath-${project.artifactId}-exist-lib</package-abbrev>
 		<package-final-name>expath-${project.artifactId}-exist-lib-${project.version}</package-final-name>
 	</properties>
@@ -30,7 +36,23 @@
 		<dependency>
 			<groupId>ro.kuberam.libs.java</groupId>
 			<artifactId>crypto</artifactId>
-			<version>1.4-SNAPSHOT</version>
+			<version>${crypto.java.lib.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.exist-db</groupId>
+			<artifactId>exist-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis</artifactId>
+			<version>1.4.01</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -38,21 +60,104 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
 				<configuration>
-					<source>${java-version}</source>
-					<target>${java-version}</target>
+					<header>LGPL2.1-template.txt</header>
+					<failIfMissing>true</failIfMissing>
+					<aggregate>true</aggregate>
+					<strictCheck>true</strictCheck>
+					<properties>
+						<owner>${project.organization.name}</owner>
+						<organization>${project.organization.name}</organization>
+						<email>exit-open@lists.sourceforge.net</email>
+						<url>${project.organization.url}</url>
+					</properties>
+					<headerDefinitions>
+						<headerDefinition>xquery-license-style.xml</headerDefinition>
+					</headerDefinitions>
+					<mapping>
+						<xq>xquery_style</xq>
+						<xqm>xquery_style</xqm>
+						<xql>xquery_style</xql>
+						<xqy>xquery_style</xqy>
+					</mapping>
+					<excludes>
+						<exclude>pom.xml</exclude>
+						<exclude>README.md</exclude>
+						<exclude>LICENSE</exclude>
+						<exclude>xquery-license-style.xml</exclude>
+						<exclude>xar-assembly.xml</exclude>
+						<exclude>org.expath.exist.crypto.launch</exclude>
+						<exclude>src/test/resources/**/*.txt</exclude>
+						<exclude>src/test/resources/**/*.xml</exclude>
+						<exclude>**/*.cer</exclude>
+						<exclude>**/*.ks</exclude>
+						<exclude>**/*.key</exclude>
+						<exclude>**/*.pem</exclude>
+						<exclude>**/*.pub</exclude>
+					</excludes>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+
+							<!-- following is needed by kuberam-expath-plugin to successfully
+                            generate its components.xml -->
+							<mainClass>${java-package-name}.${java-package-main-class-name}</mainClass>
+							<packageName>${java-package-name}</packageName>
+						</manifest>
+						<manifestEntries>
+							<Build-Tag>${build-tag}</Build-Tag>
+							<Git-Commit>${build-commit}</Git-Commit>
+							<Git-Commit-Abbrev>${build-commit-abbrev}</Git-Commit-Abbrev>
+							<Build-Version>${build-version}</Build-Version>
+							<Build-Timestamp>${build-tstamp}</Build-Timestamp>
+							<Source-Repository>${project.scm.connection}</Source-Repository>
+							<Description>${project.description}</Description>
+							<Implementation-URL>${project.url}</Implementation-URL>
+
+							<!-- following is needed by kuberam-expath-plugin to successfully
+                            generate its components.xml -->
+							<ModuleNamespace>${crypto.module.namespace}</ModuleNamespace>
+						</manifestEntries>
+					</archive>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>ro.kuberam.maven.plugins</groupId>
 				<artifactId>kuberam-expath-plugin</artifactId>
+				<version>0.4.9</version>
+				<executions>
+					<execution>
+						<id>create-xar</id>
+						<phase>package</phase>
+						<goals>
+							<goal>make-xar</goal>
+						</goals>
+						<configuration>
+							<descriptor>xar-assembly.xml</descriptor>
+							<finalName>${package-final-name}</finalName>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<!-- Attach source jars -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,18 +8,17 @@
 	<parent>
 		<groupId>org.expath.exist</groupId>
 		<artifactId>base</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>crypto</artifactId>
-	<version>0.3.5</version>
+	<version>0.4-SNAPSHOT</version>
 	<name>eXist wrapper for EXPath Cryptographic library</name>
 	<url>http://expath.org</url>
 
 	<properties>
 		<java-package-name>crypto</java-package-name>
 		<java-package-main-class-name>ExistExpathCryptoModule</java-package-main-class-name>
-		<java-lib-version>1.3.2</java-lib-version>
 		<module-prefix>${java-package-name}</module-prefix>
 		<package-title>EXPath Cryptographic Module Implementation</package-title>
 		<package-name>http://expath.org/ns/${project.artifactId}</package-name>
@@ -31,14 +30,21 @@
 		<dependency>
 			<groupId>ro.kuberam.libs.java</groupId>
 			<artifactId>crypto</artifactId>
-			<version>${java-lib-version}</version>
+			<version>1.4-SNAPSHOT</version>
 			<scope>provided</scope>
-			<type>jar</type>
 		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java-version}</source>
+					<target>${java-version}</target>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
 			<artifactId>log4j-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.evolvedbinary.j8fu</groupId>
+			<artifactId>j8fu</artifactId>
+			<version>1.9.1</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/expath/exist/crypto/ExistExpathCryptoModule.java
+++ b/src/main/java/org/expath/exist/crypto/ExistExpathCryptoModule.java
@@ -1,23 +1,21 @@
-/*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2011 The eXist Project
- *  http://exist-db.org
+/**
+ * eXist-db EXPath Cryptographic library
+ * eXist-db wrapper for EXPath Cryptographic Java library
+ * Copyright (C) 2016 Kuberam
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package org.expath.exist.crypto;
 

--- a/src/main/java/org/expath/exist/crypto/ExistExpathCryptoModule.java
+++ b/src/main/java/org/expath/exist/crypto/ExistExpathCryptoModule.java
@@ -24,8 +24,13 @@ package org.expath.exist.crypto;
 import java.util.List;
 import java.util.Map;
 
+import org.exist.dom.QName;
 import org.exist.xquery.AbstractInternalModule;
+import org.exist.xquery.FunctionDSL;
 import org.exist.xquery.FunctionDef;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.expath.exist.crypto.digest.HashFunction;
 import org.expath.exist.crypto.digest.HmacFunction;
 import org.expath.exist.crypto.digitalSignature.GenerateSignatureFunction;
@@ -34,58 +39,61 @@ import org.expath.exist.crypto.encrypt.EncryptionFunctions;
 
 import ro.kuberam.libs.java.crypto.ExpathCryptoModule;
 
+import static org.exist.xquery.FunctionDSL.functionDefs;
+
 /**
  * Implements the module definition.
- * 
+ *
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 public class ExistExpathCryptoModule extends AbstractInternalModule {
 
-	public static String NAMESPACE_URI = "";
-	static {
-		NAMESPACE_URI = ExpathCryptoModule.NAMESPACE_URI;
-	}
-	public static String PREFIX = "";
-	static {
-		PREFIX = ExpathCryptoModule.PREFIX;
-	}
-	public final static String INCLUSION_DATE = "2011-03-24";
-	public final static String RELEASED_IN_VERSION = "eXist-1.5";
+    public static final String NAMESPACE_URI = ExpathCryptoModule.NAMESPACE_URI;
+    public static final String PREFIX = ExpathCryptoModule.PREFIX;
 
-	private final static FunctionDef[] functions = {
-			new FunctionDef(HashFunction.signatures[0], HashFunction.class),
-			new FunctionDef(HashFunction.signatures[1], HashFunction.class),
-			new FunctionDef(HmacFunction.signatures[0], HmacFunction.class),
-			new FunctionDef(HmacFunction.signatures[1], HmacFunction.class),
-			new FunctionDef(GenerateSignatureFunction.signatures[0], GenerateSignatureFunction.class),
-			new FunctionDef(GenerateSignatureFunction.signatures[1], GenerateSignatureFunction.class),
-			new FunctionDef(GenerateSignatureFunction.signatures[2], GenerateSignatureFunction.class),
-			new FunctionDef(GenerateSignatureFunction.signatures[3], GenerateSignatureFunction.class),
-			new FunctionDef(ValidateSignatureFunction.signature, ValidateSignatureFunction.class),
-			new FunctionDef(EncryptionFunctions.signatures[0], EncryptionFunctions.class),
-			new FunctionDef(EncryptionFunctions.signatures[1], EncryptionFunctions.class) };
+    public final static String INCLUSION_DATE = "2011-03-24";
+    public final static String RELEASED_IN_VERSION = "eXist-1.5";
 
-	public ExistExpathCryptoModule(Map<String, List<? extends Object>> parameters) throws Exception {
-		super(functions, parameters);
-	}
+    private final static FunctionDef[] functions = functionDefs(
+            functionDefs(HashFunction.class, HashFunction.FS_HASH),
+            functionDefs(HmacFunction.class, HmacFunction.FS_HMAC),
+            functionDefs(GenerateSignatureFunction.class, GenerateSignatureFunction.FS_GENERATE_SIGNATURE),
+            functionDefs(ValidateSignatureFunction.class, ValidateSignatureFunction.FS_VALIDATE_SIGNATURE),
+            functionDefs(EncryptionFunctions.class,
+                    EncryptionFunctions.FS_ENCRYPT,
+                    EncryptionFunctions.FS_DECRYPT
+            )
+    );
 
-	@Override
-	public String getNamespaceURI() {
-		return NAMESPACE_URI;
-	}
+    public ExistExpathCryptoModule(final Map<String, List<? extends Object>> parameters) throws Exception {
+        super(functions, parameters);
+    }
 
-	@Override
-	public String getDefaultPrefix() {
-		return PREFIX;
-	}
+    @Override
+    public String getNamespaceURI() {
+        return NAMESPACE_URI;
+    }
 
-	@Override
-	public String getDescription() {
-		return ExpathCryptoModule.MODULE_DESCRIPTION;
-	}
+    @Override
+    public String getDefaultPrefix() {
+        return PREFIX;
+    }
 
-	@Override
-	public String getReleaseVersion() {
-		return RELEASED_IN_VERSION;
-	}
+    @Override
+    public String getDescription() {
+        return ExpathCryptoModule.MODULE_DESCRIPTION;
+    }
+
+    @Override
+    public String getReleaseVersion() {
+        return RELEASED_IN_VERSION;
+    }
+
+    public static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
+        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI), description, returnType, paramTypes);
+    }
+
+    public static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI), description, returnType, variableParamTypes);
+    }
 }

--- a/src/main/java/org/expath/exist/crypto/ModuleProperties.java
+++ b/src/main/java/org/expath/exist/crypto/ModuleProperties.java
@@ -1,3 +1,22 @@
+/**
+ * eXist-db EXPath Cryptographic library
+ * eXist-db wrapper for EXPath Cryptographic Java library
+ * Copyright (C) 2016 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package org.expath.exist.crypto;
 
 public class ModuleProperties {

--- a/src/main/java/org/expath/exist/crypto/digest/HashFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digest/HashFunction.java
@@ -25,7 +25,7 @@ package org.expath.exist.crypto.digest;
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 
-import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,9 +33,7 @@ import org.exist.xquery.BasicFunction;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
-import org.exist.xquery.value.Base64BinaryValueType;
 import org.exist.xquery.value.BinaryValue;
-import org.exist.xquery.value.BinaryValueFromInputStream;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.StringValue;
@@ -94,20 +92,16 @@ public class HashFunction extends BasicFunction {
             }
         } else if (inputType == Type.BASE64_BINARY || inputType == Type.HEX_BINARY) {
             try {
-                final byte[] binary = (byte[]) ((BinaryValue) args[0].itemAt(0)).toJavaObject(byte[].class);
-                final BinaryValue data = BinaryValueFromInputStream.getInstance(context,
-                        new Base64BinaryValueType(), new ByteArrayInputStream(binary));
-                result = new StringValue(Hash.hashBinary(data.getInputStream(), hashAlgorithm, encoding));
-            } catch (Exception ex) {
+                final BinaryValue binaryValue = (BinaryValue) args[0].itemAt(0);
+                try(final InputStream is = binaryValue.getInputStream()) {
+                    result = new StringValue(Hash.hashBinary(is, hashAlgorithm, encoding));
+                }
+            } catch (final Exception ex) {
                 throw new XPathException(ex.getMessage());
             }
         } else {
             result = Sequence.EMPTY_SEQUENCE;
         }
-        // ValueSequence result = new ValueSequence();
-        // for (int i = 0, il = resultBytes.length; i < il; i++) {
-        // result.add(new IntegerValue(resultBytes[i]));
-        // }
 
         return result;
     }

--- a/src/main/java/org/expath/exist/crypto/digest/HashFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digest/HashFunction.java
@@ -1,23 +1,22 @@
-/*
- *  Copyright (C) 2011 Claudius Teodorescu
+/**
+ * eXist-db EXPath Cryptographic library
+ * eXist-db wrapper for EXPath Cryptographic Java library
+ * Copyright (C) 2016 Kuberam
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-
 package org.expath.exist.crypto.digest;
 
 /**

--- a/src/main/java/org/expath/exist/crypto/digest/HashFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digest/HashFunction.java
@@ -22,16 +22,15 @@ package org.expath.exist.crypto.digest;
 
 /**
  * Implements the crypto:hash() function for eXist.
- * 
+ *
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 
 import java.io.ByteArrayInputStream;
 
-import org.apache.log4j.Logger;
-import org.exist.dom.QName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
@@ -39,77 +38,78 @@ import org.exist.xquery.value.Base64BinaryValueType;
 import org.exist.xquery.value.BinaryValue;
 import org.exist.xquery.value.BinaryValueFromInputStream;
 import org.exist.xquery.value.FunctionParameterSequenceType;
-import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.Type;
-import org.expath.exist.crypto.ExistExpathCryptoModule;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;
 
+import static org.exist.xquery.FunctionDSL.*;
+import static org.expath.exist.crypto.ExistExpathCryptoModule.*;
+
 public class HashFunction extends BasicFunction {
 
-	private final static Logger logger = Logger.getLogger(HashFunction.class);
+    private static final Logger LOG = LogManager.getLogger(HashFunction.class);
 
-	public final static FunctionSignature signatures[] = {
-			new FunctionSignature(new QName("hash", ExistExpathCryptoModule.NAMESPACE_URI,
-					ExistExpathCryptoModule.PREFIX), "Digests the input data.", new SequenceType[] {
-					new FunctionParameterSequenceType("data", Type.ANY_TYPE, Cardinality.EXACTLY_ONE,
-							"The data to be hashed."),
-					new FunctionParameterSequenceType("algorithm", Type.STRING, Cardinality.EXACTLY_ONE,
-							"The cryptographic hashing algorithm.") }, new FunctionReturnSequenceType(
-					Type.BYTE, Cardinality.ONE_OR_MORE, "resulting hash value, as string.")),
-			new FunctionSignature(
-					new QName("hash", ExistExpathCryptoModule.NAMESPACE_URI, ExistExpathCryptoModule.PREFIX),
-					"Digests the input data.",
-					new SequenceType[] {
-							new FunctionParameterSequenceType("data", Type.ANY_TYPE,
-									Cardinality.EXACTLY_ONE, "The data to be hashed."),
-							new FunctionParameterSequenceType("algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, "The cryptographic hashing algorithm."),
-							new FunctionParameterSequenceType("encoding", Type.STRING,
-									Cardinality.EXACTLY_ONE,
-									"The encoding of the output. The legal values are \"hex\" and \"base64\". The default value is \"base64\".") },
-					new FunctionReturnSequenceType(Type.BYTE, Cardinality.ONE_OR_MORE,
-							"resulting hash value, as string.")) };
+    private static final String FS_HASH_NAME = "name";
+    private static final FunctionParameterSequenceType FS_HASH_PARAM_DATA = param("data", Type.ANY_TYPE, "The data to be hashed.");
+    private static final FunctionParameterSequenceType FS_HASH_PARAM_ALGORITHM = param("algorithm", Type.STRING, "The cryptographic hashing algorithm.");
 
-	public HashFunction(XQueryContext context, FunctionSignature signature) {
-		super(context, signature);
-	}
+    public static final FunctionSignature FS_HASH[] = functionSignatures(
+        FS_HASH_NAME,
+        "resulting hash value, as string.",
+        returnsOptMany(Type.BYTE),
+        arities(
+            arity(
+                FS_HASH_PARAM_DATA,
+                FS_HASH_PARAM_ALGORITHM
+            ),
+            arity(
+                FS_HASH_PARAM_DATA,
+                FS_HASH_PARAM_ALGORITHM,
+                param("encoding", Type.STRING, "The encoding of the output. The legal values are \"hex\" and \"base64\". The default value is \"base64\".")
+            )
+        )
+    );
 
-	@Override
-	public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-		String resultString = null;
+    public HashFunction(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
 
-		int inputType = args[0].itemAt(0).getType();
-		String hashAlgorithm = args[1].getStringValue();
-		String encoding = "base64";
-		if (args.length == 3) {
-			encoding = args[2].getStringValue();
-		}
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
 
-		if (inputType == Type.STRING || inputType == Type.ELEMENT || inputType == Type.DOCUMENT) {
-			try {
-				resultString = Hash.hashString(args[0].getStringValue(), hashAlgorithm, encoding);
-			} catch (Exception ex) {
-				throw new XPathException(ex.getMessage());
-			}
-		} else if (inputType == Type.BASE64_BINARY || inputType == Type.HEX_BINARY) {
-			try {
-				byte[] binary = (byte[]) ((BinaryValue) args[0].itemAt(0)).toJavaObject(byte[].class);
-				BinaryValue data = BinaryValueFromInputStream.getInstance(context,
-						new Base64BinaryValueType(), new ByteArrayInputStream(binary));
-				resultString = Hash.hashBinary(data.getInputStream(), hashAlgorithm, encoding);
-			} catch (Exception ex) {
-				throw new XPathException(ex.getMessage());
-			}
-		}
-		// ValueSequence result = new ValueSequence();
-		// for (int i = 0, il = resultBytes.length; i < il; i++) {
-		// result.add(new IntegerValue(resultBytes[i]));
-		// }
+        final int inputType = args[0].itemAt(0).getType();
+        final String hashAlgorithm = args[1].getStringValue();
+        String encoding = "base64";
+        if (args.length == 3) {
+            encoding = args[2].getStringValue();
+        }
 
-		return new StringValue(resultString);
-	}
+        final Sequence result;
+        if (inputType == Type.STRING || inputType == Type.ELEMENT || inputType == Type.DOCUMENT) {
+            try {
+                result = new StringValue(Hash.hashString(args[0].getStringValue(), hashAlgorithm, encoding));
+            } catch (final Exception ex) {
+                throw new XPathException(ex.getMessage());
+            }
+        } else if (inputType == Type.BASE64_BINARY || inputType == Type.HEX_BINARY) {
+            try {
+                final byte[] binary = (byte[]) ((BinaryValue) args[0].itemAt(0)).toJavaObject(byte[].class);
+                final BinaryValue data = BinaryValueFromInputStream.getInstance(context,
+                        new Base64BinaryValueType(), new ByteArrayInputStream(binary));
+                result = new StringValue(Hash.hashBinary(data.getInputStream(), hashAlgorithm, encoding));
+            } catch (Exception ex) {
+                throw new XPathException(ex.getMessage());
+            }
+        } else {
+            result = Sequence.EMPTY_SEQUENCE;
+        }
+        // ValueSequence result = new ValueSequence();
+        // for (int i = 0, il = resultBytes.length; i < il; i++) {
+        // result.add(new IntegerValue(resultBytes[i]));
+        // }
+
+        return result;
+    }
 }

--- a/src/main/java/org/expath/exist/crypto/digest/HmacFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digest/HmacFunction.java
@@ -1,11 +1,22 @@
-/*
- *  eXist Java Cryptographic Extension
- *  Copyright (C) 2010 Claudius Teodorescu at http://kuberam.ro
+/**
+ * eXist-db EXPath Cryptographic library
+ * eXist-db wrapper for EXPath Cryptographic Java library
+ * Copyright (C) 2016 Kuberam
  *
- *  Released under LGPL License - http://gnu.org/licenses/lgpl.html.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-
 package org.expath.exist.crypto.digest;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/org/expath/exist/crypto/digitalSignature/GenerateSignatureFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digitalSignature/GenerateSignatureFunction.java
@@ -18,9 +18,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.Namespaces;
-import org.exist.dom.QName;
 import org.exist.dom.memtree.SAXAdapter;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
@@ -30,17 +30,13 @@ import org.exist.storage.serializers.Serializer;
 import org.exist.validation.internal.node.NodeInputStream;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.FunctionParameterSequenceType;
-import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
-import org.expath.exist.crypto.ExistExpathCryptoModule;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -52,264 +48,230 @@ import ro.kuberam.libs.java.crypto.ErrorMessages;
 import ro.kuberam.libs.java.crypto.ExpathCryptoModule;
 import ro.kuberam.libs.java.crypto.digitalSignature.GenerateXmlSignature;
 
+import static org.exist.xquery.FunctionDSL.*;
+import static org.expath.exist.crypto.ExistExpathCryptoModule.*;
+
 /**
  * @author Claudius Teodorescu (claudius.teodorescu@gmail.com)
  */
 public class GenerateSignatureFunction extends BasicFunction {
 
-	private final static Logger log = Logger.getLogger(GenerateSignatureFunction.class);
+    private static final Logger LOG = LogManager.getLogger(GenerateSignatureFunction.class);
 
-	private static String NAMESPACE_URI = ExistExpathCryptoModule.NAMESPACE_URI;
-	private static String PREFIX = ExistExpathCryptoModule.PREFIX;
-	private static String canonicalization_algorithm = ExpathCryptoModule.canonicalization_algorithm;
-	private final static String certificateRootElementName = "digital-certificate";
-	private final static String[] certificateChildElementNames = { "keystore-type", "keystore-password",
-			"key-alias", "private-key-password", "keystore-uri" };
+    private static final String FS_GENERATE_SIGNATURE_NAME = "generate-signature";
+    private static final FunctionParameterSequenceType FS_GENERATE_SIGNATURE_PARAM_DATA = param("data", Type.NODE, "The document to be signed.");
+    private static final FunctionParameterSequenceType FS_GENERATE_SIGNATURE_PARAM_CANONICALIZATION_ALGORITHM = param("canonicalization-algorithm", Type.STRING, "Canonicalization Algorithm.");
+    private static final FunctionParameterSequenceType FS_GENERATE_SIGNATURE_PARAM_DIGEST_ALGORITHM = param("digest-algorithm", Type.STRING, ExpathCryptoModule.DIGEST_ALGORITHM);
+    private static final FunctionParameterSequenceType FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_ALGORITHM = param("signature-algorithm", Type.STRING, ExpathCryptoModule.SIGNATURE_ALGORITHM);
+    private static final FunctionParameterSequenceType FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_NAMESPACE_PREFIX = param("signature-namespace-prefix", Type.STRING, "The namespace prefix for signature.");
+    private static final FunctionParameterSequenceType FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_TYPE = param("signature-type", Type.STRING, ExpathCryptoModule.SIGNATURE_TYPE);
+    private static final FunctionParameterSequenceType FS_GENERATE_SIGNATURE_PARAM_DIGITAL_CERTIFICATE = param("digital-certificate", Type.ANY_TYPE, ExpathCryptoModule.digitalCertificateDetailsDescription);
+    private static final FunctionParameterSequenceType FS_GENERATE_SIGNATURE_PARAM_XPATH = param("xpath-expression", Type.ANY_TYPE, "The XPath expression used for selecting the subset to be signed.");
 
-	public final static FunctionSignature signatures[] = {
-			new FunctionSignature(
-					new QName("generate-signature", NAMESPACE_URI, PREFIX),
-					"Generate an XML digital signature based on generated key pair. This signature is for the whole document.",
-					new SequenceType[] {
-							new FunctionParameterSequenceType("data", Type.NODE, Cardinality.EXACTLY_ONE,
-									"The document to be signed."),
-							new FunctionParameterSequenceType("canonicalization-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, canonicalization_algorithm),
-							new FunctionParameterSequenceType("digest-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.DIGEST_ALGORITHM),
-							new FunctionParameterSequenceType("signature-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.SIGNATURE_ALGORITHM),
-							new FunctionParameterSequenceType("signature-namespace-prefix", Type.STRING,
-									Cardinality.EXACTLY_ONE, "The namespace prefix for signature."),
-							new FunctionParameterSequenceType("signature-type", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.SIGNATURE_TYPE) },
-					new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
-							"the signed document (or signature) as node().")),
-			new FunctionSignature(
-					new QName("generate-signature", NAMESPACE_URI, PREFIX),
-					"Generate an XML digital signature based on generated key pair. This signature is for node(s) selected using an XPath expression",
-					new SequenceType[] {
-							new FunctionParameterSequenceType("data", Type.NODE, Cardinality.EXACTLY_ONE,
-									"The document to be signed."),
-							new FunctionParameterSequenceType("canonicalization-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, canonicalization_algorithm),
-							new FunctionParameterSequenceType("digest-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.DIGEST_ALGORITHM),
-							new FunctionParameterSequenceType("signature-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.SIGNATURE_ALGORITHM),
-							new FunctionParameterSequenceType("signature-namespace-prefix", Type.STRING,
-									Cardinality.EXACTLY_ONE, "The default namespace prefix for signature."),
-							new FunctionParameterSequenceType("signature-type", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.SIGNATURE_TYPE),
-							new FunctionParameterSequenceType("xpath-expression", Type.ANY_TYPE,
-									Cardinality.EXACTLY_ONE,
-									"The XPath expression used for selecting the subset to be signed.") },
-					new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
-							"the signed document (or signature) as node().")),
-			new FunctionSignature(
-					new QName("generate-signature", NAMESPACE_URI, PREFIX),
-					"Generate an XML digital signature based on X.509 certificate.",
-					new SequenceType[] {
-							new FunctionParameterSequenceType("data", Type.NODE, Cardinality.EXACTLY_ONE,
-									"The document to be signed."),
-							new FunctionParameterSequenceType("canonicalization-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, canonicalization_algorithm),
-							new FunctionParameterSequenceType("digest-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.DIGEST_ALGORITHM),
-							new FunctionParameterSequenceType("signature-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.SIGNATURE_ALGORITHM),
-							new FunctionParameterSequenceType("signature-namespace-prefix", Type.STRING,
-									Cardinality.EXACTLY_ONE, "The default namespace prefix for signature."),
-							new FunctionParameterSequenceType("signature-type", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.SIGNATURE_TYPE),
-							new FunctionParameterSequenceType("digital-certificate", Type.ANY_TYPE,
-									Cardinality.ONE,
-									ExpathCryptoModule.digitalCertificateDetailsDescription) },
-					new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
-							"the signed document (or signature) as node().")),
-			new FunctionSignature(
-					new QName("generate-signature", NAMESPACE_URI, PREFIX),
-					"Generate an XML digital signature based on generated key pair. This signature is for node(s) selected using an XPath expression",
-					new SequenceType[] {
-							new FunctionParameterSequenceType("data", Type.NODE, Cardinality.EXACTLY_ONE,
-									"The document to be signed."),
-							new FunctionParameterSequenceType("canonicalization-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, canonicalization_algorithm),
-							new FunctionParameterSequenceType("digest-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.DIGEST_ALGORITHM),
-							new FunctionParameterSequenceType("signature-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.SIGNATURE_ALGORITHM),
-							new FunctionParameterSequenceType("signature-namespace-prefix", Type.STRING,
-									Cardinality.EXACTLY_ONE, "The default namespace prefix for signature."),
-							new FunctionParameterSequenceType("signature-type", Type.STRING,
-									Cardinality.EXACTLY_ONE, ExpathCryptoModule.SIGNATURE_TYPE),
-							new FunctionParameterSequenceType("xpath-expression", Type.ANY_TYPE,
-									Cardinality.EXACTLY_ONE,
-									"The XPath expression used for selecting the node(s) to be signed."),
-							new FunctionParameterSequenceType("digital-certificate", Type.ANY_TYPE,
-									Cardinality.ONE,
-									ExpathCryptoModule.digitalCertificateDetailsDescription) },
-					new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
-							"the signed document (or detached signature) as node().")) };
+    public static final FunctionSignature FS_GENERATE_SIGNATURE[] = functionSignatures(
+        FS_GENERATE_SIGNATURE_NAME,
+        "Generate an XML digital signature based on generated key pair. This signature is for the whole document.",
+        returns(Type.NODE, "the signed document (or signature) as node()."),
+        arities(
+            arity(
+                FS_GENERATE_SIGNATURE_PARAM_DATA,
+                FS_GENERATE_SIGNATURE_PARAM_CANONICALIZATION_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_DIGEST_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_NAMESPACE_PREFIX,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_TYPE
+            ),
+            arity(
+                FS_GENERATE_SIGNATURE_PARAM_DATA,
+                FS_GENERATE_SIGNATURE_PARAM_CANONICALIZATION_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_DIGEST_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_NAMESPACE_PREFIX,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_TYPE,
+                FS_GENERATE_SIGNATURE_PARAM_XPATH
+            ),
+            arity(
+                FS_GENERATE_SIGNATURE_PARAM_DATA,
+                FS_GENERATE_SIGNATURE_PARAM_CANONICALIZATION_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_DIGEST_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_NAMESPACE_PREFIX,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_TYPE,
+                FS_GENERATE_SIGNATURE_PARAM_DIGITAL_CERTIFICATE
+            ),
+            arity(
+                FS_GENERATE_SIGNATURE_PARAM_DATA,
+                FS_GENERATE_SIGNATURE_PARAM_CANONICALIZATION_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_DIGEST_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_ALGORITHM,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_NAMESPACE_PREFIX,
+                FS_GENERATE_SIGNATURE_PARAM_SIGNATURE_TYPE,
+                FS_GENERATE_SIGNATURE_PARAM_XPATH,
+                FS_GENERATE_SIGNATURE_PARAM_DIGITAL_CERTIFICATE
+            )
+        )
+    );
 
-	public GenerateSignatureFunction(XQueryContext context, FunctionSignature signature) {
-		super(context, signature);
-	}
+    private static final String certificateRootElementName = "digital-certificate";
+    private static final String[] certificateChildElementNames = {"keystore-type", "keystore-password",
+            "key-alias", "private-key-password", "keystore-uri"};
 
-	public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-		Serializer serializer = context.getBroker().getSerializer();
-		NodeValue inputNode = (NodeValue) args[0].itemAt(0);
-		InputStream inputNodeStream = new NodeInputStream(serializer, inputNode);
-		Document inputDOMDoc = inputStreamToDocument(inputNodeStream);
+    public GenerateSignatureFunction(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
 
-		String canonicalizationAlgorithm = args[1].getStringValue();
-		String digestAlgorithm = args[2].getStringValue();
-		String signatureAlgorithm = args[3].getStringValue();
-		String signatureNamespacePrefix = args[4].getStringValue();
-		String signatureType = args[5].getStringValue();
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final Serializer serializer = context.getBroker().getSerializer();
+        final NodeValue inputNode = (NodeValue) args[0].itemAt(0);
+        final InputStream inputNodeStream = new NodeInputStream(serializer, inputNode);
+        final Document inputDOMDoc = inputStreamToDocument(inputNodeStream);
 
-		String signatureString = null;
-		Document signatureDocument = null;
+        final String canonicalizationAlgorithm = args[1].getStringValue();
+        final String digestAlgorithm = args[2].getStringValue();
+        final String signatureAlgorithm = args[3].getStringValue();
+        final String signatureNamespacePrefix = args[4].getStringValue();
+        final String signatureType = args[5].getStringValue();
 
-		// get the XPath expression and/or the certificate's details
-		String xpathExprString = null;
-		String[] certificateDetails = new String[5];
-		certificateDetails[0] = "";
-		InputStream keyStoreInputStream = null;
+        String signatureString = null;
+        Document signatureDocument = null;
 
-		// function with 7 arguments
-		if (args.length == 7) {
-			if (args[6].itemAt(0).getType() == 22) {
-				xpathExprString = args[6].getStringValue();
-			} else if (args[6].itemAt(0).getType() == 1) {
-				Node certificateDetailsNode = ((NodeValue) args[6].itemAt(0)).getNode();
-				// get the certificate details
-				certificateDetails = getDigitalCertificateDetails(certificateDetails,
-						certificateDetailsNode);
-				// get the keystore InputStream
-				keyStoreInputStream = getKeyStoreInputStream(keyStoreInputStream, certificateDetails[4]);
-			}
-		}
+        // get the XPath expression and/or the certificate's details
+        String xpathExprString = null;
+        String[] certificateDetails = new String[5];
+        certificateDetails[0] = "";
+        InputStream keyStoreInputStream = null;
 
-		// function with 8 arguments
-		if (args.length == 8) {
-			xpathExprString = args[6].getStringValue();
-			Node certificateDetailsNode = ((NodeValue) args[7].itemAt(0)).getNode();
-			// get the certificate details
-			certificateDetails = getDigitalCertificateDetails(certificateDetails, certificateDetailsNode);
-			// get the keystore InputStream
-			keyStoreInputStream = getKeyStoreInputStream(keyStoreInputStream, certificateDetails[4]);
-		}
+        // function with 7 arguments
+        if (args.length == 7) {
+            if (args[6].itemAt(0).getType() == 22) {
+                xpathExprString = args[6].getStringValue();
+            } else if (args[6].itemAt(0).getType() == 1) {
+                final Node certificateDetailsNode = ((NodeValue) args[6].itemAt(0)).getNode();
+                // get the certificate details
+                certificateDetails = getDigitalCertificateDetails(certificateDetails,
+                        certificateDetailsNode);
+                // get the keystore InputStream
+                keyStoreInputStream = getKeyStoreInputStream(certificateDetails[4]);
+            }
+        }
 
-		try {
-			signatureString = GenerateXmlSignature.generate(inputDOMDoc, canonicalizationAlgorithm,
-					digestAlgorithm, signatureAlgorithm, signatureNamespacePrefix, signatureType,
-					xpathExprString, certificateDetails, keyStoreInputStream);
-		} catch (Exception ex) {
-			throw new XPathException(ex.getMessage());
-		}
+        // function with 8 arguments
+        if (args.length == 8) {
+            xpathExprString = args[6].getStringValue();
+            final Node certificateDetailsNode = ((NodeValue) args[7].itemAt(0)).getNode();
+            // get the certificate details
+            certificateDetails = getDigitalCertificateDetails(certificateDetails, certificateDetailsNode);
+            // get the keystore InputStream
+            keyStoreInputStream = getKeyStoreInputStream(certificateDetails[4]);
+        }
 
-		try {
-			signatureDocument = stringToDocument(signatureString);
-		} catch (Exception ex) {
-			throw new XPathException(ex.getMessage());
-		}
+        try {
+            signatureString = GenerateXmlSignature.generate(inputDOMDoc, canonicalizationAlgorithm,
+                    digestAlgorithm, signatureAlgorithm, signatureNamespacePrefix, signatureType,
+                    xpathExprString, certificateDetails, keyStoreInputStream);
+        } catch (final Exception ex) {
+            throw new XPathException(ex.getMessage());
+        }
 
-		return (Sequence) (DocumentImpl) signatureDocument;
-	}
+        try {
+            signatureDocument = stringToDocument(signatureString);
+        } catch (final Exception ex) {
+            throw new XPathException(ex.getMessage());
+        }
 
-	private Document stringToDocument(String signatureString) throws Exception {
-		// process the output (signed) document from string to node()
-		SAXAdapter adapter = null;
-		try {
-			SAXParserFactory factory = SAXParserFactory.newInstance();
-			factory.setNamespaceAware(true);
-			SAXParser parser = factory.newSAXParser();
-			XMLReader xr = parser.getXMLReader();
-			adapter = new SAXAdapter(context);
-			xr.setContentHandler(adapter);
-			xr.setProperty(Namespaces.SAX_LEXICAL_HANDLER, adapter);
-			xr.parse(new InputSource(new StringReader(signatureString)));
-		} catch (ParserConfigurationException e) {
-			throw new XPathException("Error while constructing XML parser: " + e.getMessage());
-		} catch (SAXException e) {
-			throw new XPathException("Error while parsing XML: " + e.getMessage());
-		} catch (IOException e) {
-			throw new XPathException("Error while parsing XML: " + e.getMessage());
-		}
+        return (Sequence) signatureDocument;
+    }
 
-		return adapter.getDocument();
-	}
+    private Document stringToDocument(final String signatureString) throws Exception {
+        // process the output (signed) document from string to node()
+        try {
+            final SAXParserFactory factory = SAXParserFactory.newInstance();
+            factory.setNamespaceAware(true);
+            final SAXParser parser = factory.newSAXParser();
+            final XMLReader xr = parser.getXMLReader();
+            final SAXAdapter adapter = new SAXAdapter(context);
+            xr.setContentHandler(adapter);
+            xr.setProperty(Namespaces.SAX_LEXICAL_HANDLER, adapter);
+            xr.parse(new InputSource(new StringReader(signatureString)));
 
-	private String[] getDigitalCertificateDetails(String[] certificateDetails, Node certificateDetailsNode)
-			throws XPathException {
-		if (!certificateDetailsNode.getNodeName().equals(certificateRootElementName)) {
-			throw new XPathException(ErrorMessages.error_sigElem);
-			// TODO: here was err:CX05 The root element of argument
-			// $digital-certificate must have the name 'digital-certificate'.
-		}
-		NodeList certificateDetailsNodeList = certificateDetailsNode.getChildNodes();
-		for (int i = 0, il = certificateDetailsNodeList.getLength(); i < il; i++) {
-			Node child = certificateDetailsNodeList.item(i);
-			if (child.getNodeName().equals(certificateChildElementNames[i])) {
-				certificateDetails[i] = child.getFirstChild().getNodeValue();
-			} else {
-				throw new XPathException(ErrorMessages.error_sigElem);
-				// TODO: here was err:CX05 The root element of argument
-				// $digital-certificate must have the name
-				// 'digital-certificate'.
-			}
-		}
-		return certificateDetails;
-	}
+            return adapter.getDocument();
 
-	private InputStream getKeyStoreInputStream(InputStream keyStoreInputStream, String keystoreURI)
-			throws XPathException {
-		// get the keystore as InputStream
-		DocumentImpl keyStoreDoc = null;
-		try {
-			try {
-				keyStoreDoc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(keystoreURI),
-						Lock.READ_LOCK);
-				if (keyStoreDoc == null) {
-					throw new XPathException(ErrorMessages.error_readKeystore);
-					// TODO: here was err:CX07 The keystore is null.
-				}
-				BinaryDocument keyStoreBinaryDoc = (BinaryDocument) keyStoreDoc;
-				try {
-					keyStoreInputStream = context.getBroker().getBinaryResource(keyStoreBinaryDoc);
-				} catch (IOException ex) {
-					throw new XPathException(ErrorMessages.error_readKeystore);
-				}
-			} catch (PermissionDeniedException ex) {
-				log.info(ErrorMessages.error_deniedKeystore);
-			}
-		} catch (URISyntaxException ex) {
-			log.error(ErrorMessages.error_keystoreUrl);
-		}
-		return keyStoreInputStream;
-	}
+        } catch (final ParserConfigurationException e) {
+            throw new XPathException("Error while constructing XML parser: " + e.getMessage());
+        } catch (final SAXException | IOException e) {
+            throw new XPathException("Error while parsing XML: " + e.getMessage());
+        }
+    }
 
-	private Document inputStreamToDocument(InputStream inputStream) {
-		// initialize the document builder
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		dbf.setNamespaceAware(true);
-		DocumentBuilder db = null;
-		try {
-			db = dbf.newDocumentBuilder();
-		} catch (ParserConfigurationException ex) {
-		}
+    private String[] getDigitalCertificateDetails(final String[] certificateDetails, final Node certificateDetailsNode)
+            throws XPathException {
+        if (!certificateDetailsNode.getNodeName().equals(certificateRootElementName)) {
+            throw new XPathException(ErrorMessages.error_sigElem);
+            // TODO: here was err:CX05 The root element of argument
+            // $digital-certificate must have the name 'digital-certificate'.
+        }
 
-		// convert data to DOM document
-		Document document = null;
-		try {
-			document = db.parse(inputStream);
-		} catch (SAXException ex) {
-			ex.getMessage();
-		} catch (IOException ex) {
-			ex.getMessage();
-		}
+        final NodeList certificateDetailsNodeList = certificateDetailsNode.getChildNodes();
+        for (int i = 0, il = certificateDetailsNodeList.getLength(); i < il; i++) {
+            final Node child = certificateDetailsNodeList.item(i);
+            if (child.getNodeName().equals(certificateChildElementNames[i])) {
+                certificateDetails[i] = child.getFirstChild().getNodeValue();
+            } else {
+                throw new XPathException(ErrorMessages.error_sigElem);
+                // TODO: here was err:CX05 The root element of argument
+                // $digital-certificate must have the name
+                // 'digital-certificate'.
+            }
+        }
+        return certificateDetails;
+    }
 
-		return document;
-	}
+    private InputStream getKeyStoreInputStream(final String keystoreURI) throws XPathException {
+        // get the keystore as InputStream
+        try {
+            try {
+                final DocumentImpl keyStoreDoc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(keystoreURI), Lock.LockMode.READ_LOCK);
+                if (keyStoreDoc == null) {
+                    throw new XPathException(ErrorMessages.error_readKeystore);
+                    // TODO: here was err:CX07 The keystore is null.
+                }
+
+                final BinaryDocument keyStoreBinaryDoc = (BinaryDocument) keyStoreDoc;
+                try {
+                    return context.getBroker().getBinaryResource(keyStoreBinaryDoc);
+                } catch (final IOException ex) {
+                    throw new XPathException(ErrorMessages.error_readKeystore);
+                }
+
+            } catch (final PermissionDeniedException ex) {
+                LOG.error(ErrorMessages.error_deniedKeystore);
+                return null;
+            }
+        } catch (final URISyntaxException ex) {
+            LOG.error(ErrorMessages.error_keystoreUrl);
+            return null;
+        }
+    }
+
+    private Document inputStreamToDocument(final InputStream inputStream) {
+        // initialize the document builder
+        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = null;
+        try {
+            db = dbf.newDocumentBuilder();
+        } catch (ParserConfigurationException ex) {
+        }
+
+        // convert data to DOM document
+        Document document = null;
+        try {
+            document = db.parse(inputStream);
+        } catch (SAXException | IOException ex) {
+            ex.getMessage();
+        }
+
+        return document;
+    }
 }

--- a/src/main/java/org/expath/exist/crypto/digitalSignature/GenerateSignatureFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digitalSignature/GenerateSignatureFunction.java
@@ -1,9 +1,21 @@
-/*
- *  eXist Java Cryptographic Extension
- *  Copyright (C) 2010 Claudius Teodorescu at http://kuberam.ro
- *  
- *  Released under LGPL License - http://gnu.org/licenses/lgpl.html.
- *  
+/**
+ * eXist-db EXPath Cryptographic library
+ * eXist-db wrapper for EXPath Cryptographic Java library
+ * Copyright (C) 2016 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package org.expath.exist.crypto.digitalSignature;
 

--- a/src/main/java/org/expath/exist/crypto/digitalSignature/ValidateSignatureFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digitalSignature/ValidateSignatureFunction.java
@@ -20,6 +20,7 @@
 package org.expath.exist.crypto.digitalSignature;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.io.StringReader;
 import java.util.Properties;
 
@@ -106,8 +107,8 @@ public class ValidateSignatureFunction extends BasicFunction {
 
         //process the input string to DOM document
         Document inputDOMDoc = null;
-        try {
-            inputDOMDoc = db.parse(new InputSource(new StringReader(serializer.serialize((NodeValue) args[0].itemAt(0)))));
+        try(final Reader reader = new StringReader(serializer.serialize((NodeValue) args[0].itemAt(0)))) {
+            inputDOMDoc = db.parse(new InputSource(reader));
         } catch (final SAXException | IOException ex) {
             LOG.error(ex.getMessage(), ex);
         }

--- a/src/main/java/org/expath/exist/crypto/digitalSignature/ValidateSignatureFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digitalSignature/ValidateSignatureFunction.java
@@ -10,29 +10,23 @@ package org.expath.exist.crypto.digitalSignature;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Properties;
-import java.util.logging.Level;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 
-import org.apache.log4j.Logger;
-import org.exist.dom.QName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.storage.serializers.Serializer;
 import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.BooleanValue;
-import org.exist.xquery.value.FunctionParameterSequenceType;
-import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
-import org.expath.exist.crypto.ExistExpathCryptoModule;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -41,78 +35,80 @@ import org.xml.sax.SAXNotSupportedException;
 
 import ro.kuberam.libs.java.crypto.digitalSignature.ValidateXmlSignature;
 
+import static org.exist.xquery.FunctionDSL.*;
+import static org.expath.exist.crypto.ExistExpathCryptoModule.*;
+
 /**
  * Cryptographic extension functions.
- * 
+ *
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 public class ValidateSignatureFunction extends BasicFunction {
 
-	private final static Logger logger = Logger.getLogger(ValidateSignatureFunction.class);
+    private static final Logger LOG = LogManager.getLogger(ValidateSignatureFunction.class);
 
-	public final static FunctionSignature signature =
-		new FunctionSignature(
-			new QName("validate-signature", ExistExpathCryptoModule.NAMESPACE_URI, ExistExpathCryptoModule.PREFIX),
-			"This function validates an XML Digital Signature.",
-			new SequenceType[] {
-                            new FunctionParameterSequenceType("data", Type.NODE, Cardinality.EXACTLY_ONE, "The enveloped, enveloping, or detached signature.")                        },
-			new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "boolean value true() if the signature is valid, otherwise return value false()."));
+    public final static FunctionSignature FS_VALIDATE_SIGNATURE = functionSignature(
+        "validate-signature",
+        "This function validates an XML Digital Signature.",
+        returns(Type.BOOLEAN, "boolean value true() if the signature is valid, otherwise return value false()."),
+        param("data", Type.NODE, "The enveloped, enveloping, or detached signature.")
+    );
 
-	public ValidateSignatureFunction(XQueryContext context, FunctionSignature signature) {
-		super(context, signature);
-	}
+    public ValidateSignatureFunction(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
 
-	protected final static Properties defaultOutputKeysProperties = new Properties();
-	static {
-		defaultOutputKeysProperties.setProperty(OutputKeys.INDENT, "no");
-		defaultOutputKeysProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-		defaultOutputKeysProperties.setProperty(OutputKeys.ENCODING, "UTF-8");
-	}
+    private static final Properties defaultOutputKeysProperties = new Properties();
+    static {
+        defaultOutputKeysProperties.setProperty(OutputKeys.INDENT, "no");
+        defaultOutputKeysProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        defaultOutputKeysProperties.setProperty(OutputKeys.ENCODING, "UTF-8");
+    }
 
-	public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-            if( args[0].isEmpty() ){
-                return Sequence.EMPTY_SEQUENCE;
-            }
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        if (args[0].isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
 
-            //get and process the input document or node to InputStream, in order to be transformed into DOM Document
-            Serializer serializer = context.getBroker().getSerializer();
-            serializer.reset();
-            Properties outputProperties = new Properties( defaultOutputKeysProperties );
-            try {
-                serializer.setProperties(outputProperties);
-            } catch (SAXNotRecognizedException ex) {
-            java.util.logging.Logger.getLogger(ValidateSignatureFunction.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (SAXNotSupportedException ex) {
-            java.util.logging.Logger.getLogger(ValidateSignatureFunction.class.getName()).log(Level.SEVERE, null, ex);
-            }
+        //get and process the input document or node to InputStream, in order to be transformed into DOM Document
+        final Serializer serializer = context.getBroker().getSerializer();
+        serializer.reset();
 
-            //initialize the document builder
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            dbf.setNamespaceAware(true);
-            DocumentBuilder db = null;
-            try {
-                db = dbf.newDocumentBuilder();
-            } catch (ParserConfigurationException ex) {}
+        final Properties outputProperties = new Properties(defaultOutputKeysProperties);
+        try {
+            serializer.setProperties(outputProperties);
+        } catch (final SAXNotRecognizedException | SAXNotSupportedException ex) {
+            LOG.error(ex.getMessage(), ex);
+        }
 
-            //process the input string to DOM document
-            Document inputDOMDoc = null;
-            try {
-                inputDOMDoc = db.parse(new InputSource(new StringReader(serializer.serialize((NodeValue)args[0].itemAt(0)))));
-            } catch (SAXException ex) {
-                ex.getMessage();
-            } catch (IOException ex) {
-                ex.getMessage();
-            }
+        //initialize the document builder
+        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = null;
+        try {
+            db = dbf.newDocumentBuilder();
+        } catch (final ParserConfigurationException ex) {
+            LOG.error(ex.getMessage(), ex);
+        }
 
-            //validate the signature
-            Boolean isValid = false;
-            try {
-                isValid = ValidateXmlSignature.validate(inputDOMDoc);
+        //process the input string to DOM document
+        Document inputDOMDoc = null;
+        try {
+            inputDOMDoc = db.parse(new InputSource(new StringReader(serializer.serialize((NodeValue) args[0].itemAt(0)))));
+        } catch (final SAXException | IOException ex) {
+            LOG.error(ex.getMessage(), ex);
+        }
+
+        //validate the signature
+        Boolean isValid = false;
+        try {
+            isValid = ValidateXmlSignature.validate(inputDOMDoc);
 //            	isValid = ValidateXmlSignature.validate((Document)args[0].itemAt(0));
-            } catch (Exception ex) {
-                throw new XPathException(ex.getMessage());
-            }
+        } catch (final Exception ex) {
+            throw new XPathException(ex.getMessage());
+        }
 
-            return new BooleanValue(isValid);
-     }
+        return new BooleanValue(isValid);
+    }
 }

--- a/src/main/java/org/expath/exist/crypto/digitalSignature/ValidateSignatureFunction.java
+++ b/src/main/java/org/expath/exist/crypto/digitalSignature/ValidateSignatureFunction.java
@@ -1,9 +1,21 @@
-/*
- *  eXist Java Cryptographic Extension
- *  Copyright (C) 2010 Claudius Teodorescu at http://kuberam.ro
- *  
- *  Released under LGPL License - http://gnu.org/licenses/lgpl.html.
- *  
+/**
+ * eXist-db EXPath Cryptographic library
+ * eXist-db wrapper for EXPath Cryptographic Java library
+ * Copyright (C) 2016 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package org.expath.exist.crypto.digitalSignature;
 

--- a/src/main/java/org/expath/exist/crypto/encrypt/EncryptionFunctions.java
+++ b/src/main/java/org/expath/exist/crypto/encrypt/EncryptionFunctions.java
@@ -8,24 +8,23 @@
 
 package org.expath.exist.crypto.encrypt;
 
-import org.apache.log4j.Logger;
-import org.exist.dom.QName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
-import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.StringValue;
-import org.expath.exist.crypto.ExistExpathCryptoModule;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;
 import ro.kuberam.libs.java.crypto.encrypt.AsymmetricEncryption;
 import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
+
+import static org.exist.xquery.FunctionDSL.*;
+import static org.expath.exist.crypto.ExistExpathCryptoModule.*;
 
 /**
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
@@ -33,84 +32,76 @@ import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
 
 public class EncryptionFunctions extends BasicFunction {
 
-	private final static Logger log = Logger.getLogger(EncryptionFunctions.class);
+    private static final Logger LOG = LogManager.getLogger(EncryptionFunctions.class);
 
-	public final static FunctionSignature signatures[] = {
-			new FunctionSignature(
-					new QName("encrypt", ExistExpathCryptoModule.NAMESPACE_URI,
-							ExistExpathCryptoModule.PREFIX),
-					"Encrypts the input string.",
-					new SequenceType[] {
-							new FunctionParameterSequenceType("data", Type.STRING, Cardinality.EXACTLY_ONE,
-									"The data to be encrypted. This parameter can be of type xs:string, xs:base64Binary, or xs:hexBinary."),
-							new FunctionParameterSequenceType("encryption-type", Type.STRING,
-									Cardinality.EXACTLY_ONE,
-									"The type of encryption. Legal values: 'symmetric', and 'asymmetric'."),
-							new FunctionParameterSequenceType("secret-key", Type.STRING,
-									Cardinality.EXACTLY_ONE,
-									"The secret key used for encryption, as string."),
-							new FunctionParameterSequenceType("cryptographic-algorithm", Type.STRING,
-									Cardinality.EXACTLY_ONE,
-									"The cryptographic algorithm used for encryption."),
-							new FunctionParameterSequenceType("iv", Type.STRING, Cardinality.ZERO_OR_ONE,
-									"The initialization vector."),
-							new FunctionParameterSequenceType("provider", Type.STRING,
-									Cardinality.ZERO_OR_ONE, "The cryptographic provider.") },
-					new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE,
-							"the encrypted data.")),
-			new FunctionSignature(new QName("decrypt", ExistExpathCryptoModule.NAMESPACE_URI,
-					ExistExpathCryptoModule.PREFIX), "Decrypts the input string.", new SequenceType[] {
-					new FunctionParameterSequenceType("data", Type.STRING, Cardinality.EXACTLY_ONE,
-							"The data to be decrypted."),
-					new FunctionParameterSequenceType("decryption-type", Type.STRING,
-							Cardinality.EXACTLY_ONE,
-							"The type of decryption. Legal values: 'symmetric', and 'asymmetric'."),
-					new FunctionParameterSequenceType("secret-key", Type.STRING, Cardinality.EXACTLY_ONE,
-							"The secret key used for decryption, as string."),
-					new FunctionParameterSequenceType("cryptographic-algorithm", Type.STRING,
-							Cardinality.EXACTLY_ONE, "The cryptographic algorithm used for decryption."),
-					new FunctionParameterSequenceType("iv", Type.STRING, Cardinality.ZERO_OR_ONE,
-							"The initialization vector."),
-					new FunctionParameterSequenceType("provider", Type.STRING, Cardinality.ZERO_OR_ONE,
-							"The cryptographic provider.") }, new FunctionReturnSequenceType(Type.STRING,
-					Cardinality.EXACTLY_ONE, "the decrypted data.")) };
+    private static final String FS_ENCRYPT_NAME = "encrypt";
+    private static final String FS_DECRYPT_NAME = "decrypt";
+    private static final FunctionParameterSequenceType FS_ENCRYPT_PARAM_DATA = param("data", Type.ATOMIC, "The data to be encrypted or decrypted. This parameter can be of type xs:string, xs:base64Binary, or xs:hexBinary.");
+    private static final FunctionParameterSequenceType FS_ENCRYPT_PARAM_SECRET_KEY = param("secret-key", Type.STRING, "The secret key used for encryption or decryption, as string.");
+    private static final FunctionParameterSequenceType FS_ENCRYPT_PARAM_CRYPTOGRAPHIC_ALGORITHM = param("secret-key", Type.STRING, "The cryptographic algorithm used for encryption or decryption.");
+    private static final FunctionParameterSequenceType FS_ENCRYPT_PARAM_IV = optParam("secret-key", Type.STRING, "The initialization vector.");
+    private static final FunctionParameterSequenceType FS_ENCRYPT_PARAM_PROVIDER = optParam("provider", Type.STRING, "The cryptographic provider.");
 
-	public EncryptionFunctions(XQueryContext context, FunctionSignature signature) {
-		super(context, signature);
-	}
+    public final static FunctionSignature FS_ENCRYPT = functionSignature(
+        FS_ENCRYPT_NAME,
+        "Encrypts the input string.",
+        returns(Type.STRING, "the encrypted data."),
+        FS_ENCRYPT_PARAM_DATA,
+        param("encryption-type", Type.STRING, "The type of encryption. Legal values: 'symmetric', and 'asymmetric'."),
+        FS_ENCRYPT_PARAM_SECRET_KEY,
+        FS_ENCRYPT_PARAM_CRYPTOGRAPHIC_ALGORITHM,
+        FS_ENCRYPT_PARAM_IV,
+        FS_ENCRYPT_PARAM_PROVIDER
+    );
 
-	public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-		String result = null;
-		String functionName = getSignature().getName().getLocalPart();
+    public final static FunctionSignature FS_DECRYPT = functionSignature(
+            FS_DECRYPT_NAME,
+            "Decrypts the input string.",
+            returns(Type.STRING, "the decrypted data."),
+            FS_ENCRYPT_PARAM_DATA,
+            param("decryption-type", Type.STRING, "The type of decryption. Legal values: 'symmetric', and 'asymmetric'."),
+            FS_ENCRYPT_PARAM_SECRET_KEY,
+            FS_ENCRYPT_PARAM_CRYPTOGRAPHIC_ALGORITHM,
+            FS_ENCRYPT_PARAM_IV,
+            FS_ENCRYPT_PARAM_PROVIDER
+    );
 
-		try {
-			if ("encrypt".equals(functionName)) {
-				if ("symmetric".equals(args[1].getStringValue())) {
-					result = SymmetricEncryption.encryptString(args[0].getStringValue(),
-							args[2].getStringValue(), args[3].getStringValue(), args[4].getStringValue(),
-							args[5].getStringValue());
-				} else if ("asymmetric".equals(args[1].getStringValue())) {
-					result = AsymmetricEncryption.encryptString(args[0].getStringValue(),
-							args[2].getStringValue(), args[3].getStringValue());
-				} else {
-					throw new XPathException(ErrorMessages.error_encType);
-				}
-			} else if ("decrypt".equals(functionName)) {
-				if ("symmetric".equals(args[1].getStringValue())) {
-					result = SymmetricEncryption.decryptString(args[0].getStringValue(),
-							args[2].getStringValue(), args[3].getStringValue(), args[4].getStringValue(),
-							args[5].getStringValue());
-				} else if ("asymmetric".equals(args[1].getStringValue())) {
+    public EncryptionFunctions(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
 
-				} else {
-					throw new XPathException(ErrorMessages.error_decryptionType);
-				}
-			}
-		} catch (Exception ex) {
-			throw new XPathException(ex.getMessage());
-		}
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        String result = null;
+        final String functionName = getSignature().getName().getLocalPart();
 
-		return new StringValue(result);
-	}
+        try {
+            if ("encrypt".equals(functionName)) {
+                if ("symmetric".equals(args[1].getStringValue())) {
+                    result = SymmetricEncryption.encryptString(args[0].getStringValue(),
+                            args[2].getStringValue(), args[3].getStringValue(), args[4].getStringValue(),
+                            args[5].getStringValue());
+                } else if ("asymmetric".equals(args[1].getStringValue())) {
+                    result = AsymmetricEncryption.encryptString(args[0].getStringValue(),
+                            args[2].getStringValue(), args[3].getStringValue());
+                } else {
+                    throw new XPathException(ErrorMessages.error_encType);
+                }
+            } else if ("decrypt".equals(functionName)) {
+                if ("symmetric".equals(args[1].getStringValue())) {
+                    result = SymmetricEncryption.decryptString(args[0].getStringValue(),
+                            args[2].getStringValue(), args[3].getStringValue(), args[4].getStringValue(),
+                            args[5].getStringValue());
+                } else if ("asymmetric".equals(args[1].getStringValue())) {
 
+                } else {
+                    throw new XPathException(ErrorMessages.error_decryptionType);
+                }
+            }
+        } catch (final Exception ex) {
+            throw new XPathException(ex.getMessage());
+        }
+
+        return new StringValue(result);
+    }
 }

--- a/src/main/java/org/expath/exist/crypto/encrypt/EncryptionFunctions.java
+++ b/src/main/java/org/expath/exist/crypto/encrypt/EncryptionFunctions.java
@@ -1,11 +1,22 @@
-/*
- *  eXist Java Cryptographic Extension
- *  Copyright (C) 2010 Claudius Teodorescu at http://kuberam.ro
+/**
+ * eXist-db EXPath Cryptographic library
+ * eXist-db wrapper for EXPath Cryptographic Java library
+ * Copyright (C) 2016 Kuberam
  *
- *  Released under LGPL License - http://gnu.org/licenses/lgpl.html.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-
 package org.expath.exist.crypto.encrypt;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/test/java/org/expath/exist/crypto/test-plan.xml
+++ b/src/test/java/org/expath/exist/crypto/test-plan.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    eXist-db EXPath Cryptographic library
+    eXist-db wrapper for EXPath Cryptographic Java library
+    Copyright (C) 2016 Kuberam
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public License
+    as published by the Free Software Foundation; either version 2.1
+    of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library; if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+-->
 <kert:test-plan xmlns="http://www.w3.org/1999/xhtml" xmlns:kert="http://kuberam.ro/ns/kert" test-plan-version="0.5" xml:base="unit-tests/">
     <kert:description>Test plan for EXPath Cryptographic Module</kert:description>
     <kert:version>0.6</kert:version>

--- a/src/test/java/org/expath/exist/crypto/xquery/AwsRestRequest.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/AwsRestRequest.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/AwsRestRequestWithDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/AwsRestRequestWithDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/decryptStringWithAesSymmetricKeyCbcMode.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/decryptStringWithAesSymmetricKeyCbcMode.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/decryptStringWithAesSymmetricKeyCbcModeDefaultProvider.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/decryptStringWithAesSymmetricKeyCbcModeDefaultProvider.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/decryptStringWithAesSymmetricKeyEcbMode.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/decryptStringWithAesSymmetricKeyEcbMode.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesSymmetricKeyCbcMode.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesSymmetricKeyCbcMode.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesSymmetricKeyCbcModeDefaultProvider.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesSymmetricKeyCbcModeDefaultProvider.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesSymmetricKeyEcbMode.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesSymmetricKeyEcbMode.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesWrongSymmetricKeyCbcMode.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesWrongSymmetricKeyCbcMode.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesWrongSymmetricKeyCbcModeDefaultProvider.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/encryptStringWithAesWrongSymmetricKeyCbcModeDefaultProvider.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/generateEnvelopedDigitalSignature.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/generateEnvelopedDigitalSignature.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithMd5.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithMd5.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithMd5AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithMd5AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha1.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha1.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha1AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha1AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha256.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha256.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha256AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha256AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha384.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha384.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha384AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha384AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha512.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha512.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha512AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithSha512AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithWrongAlgorithm.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithWrongAlgorithm.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithWrongAlgorithmAndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashBinaryWithWrongAlgorithmAndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithMd5.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithMd5.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithMd5AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithMd5AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha1.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha1.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha1AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha1AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha256.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha256.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha256AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha256AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha384.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha384.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha384AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha384AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha512.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha512.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha512AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashStringWithSha512AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashXmlWithMd5.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashXmlWithMd5.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hashXmlWithMd5AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hashXmlWithMd5AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithMd5.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithMd5.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithMd5AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithMd5AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha1.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha1.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha1AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha1AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha256.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha256.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha256AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha256AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha384.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha384.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha384AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha384AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha512.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha512.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha512AndDefaultFormat.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/hmacStringWithSha512AndDefaultFormat.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/src/test/java/org/expath/exist/crypto/xquery/validateEnvelopedDigitalSignature.xq
+++ b/src/test/java/org/expath/exist/crypto/xquery/validateEnvelopedDigitalSignature.xq
@@ -1,3 +1,22 @@
+(:
+ : eXist-db EXPath Cryptographic library
+ : eXist-db wrapper for EXPath Cryptographic Java library
+ : Copyright (C) 2016 Kuberam
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public License
+ : as published by the Free Software Foundation; either version 2.1
+ : of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ : GNU Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public License
+ : along with this library; if not, write to the Free Software Foundation,
+ : Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ :)
 xquery version "3.0";
 
 import module "http://expath.org/ns/crypto";

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -3,7 +3,7 @@
 	<title>${package-title}</title>
 	<author id="cteodorescu">Claudius Teodorescu</author>
 	<website>${project.url}</website>
-	<license>GNU-LGPL</license>
+	<license>GNU LGPL v2.1</license>
 	<copyright>true</copyright>
 	<type>library</type>
 	<status>stable</status>
@@ -13,19 +13,19 @@
 	<tag>exist</tag>
 	<category id="libs">Libraries</category>
 	<category id="exist">eXist extensions</category>
-	<dependency processor="http://exist-db.org" semver-min="2.3.0" />
+	<dependency processor="http://exist-db.org" semver-min="3.5.0" />
 	<dependencySets>
 		<dependencySet>
-			<groupId>org.expath.exist</groupId>
-			<artifactId>crypto</artifactId>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>${project.artifactId}</artifactId>
 			<version>${project.version}</version>
-			<outputFileNameMapping>crypto-exist-java-lib.jar</outputFileNameMapping>
+			<outputFileNameMapping>${project.artifactId}-exist-java-lib-${project.version}.jar</outputFileNameMapping>
 		</dependencySet>
 		<dependencySet>
 			<groupId>ro.kuberam.libs.java</groupId>
 			<artifactId>crypto</artifactId>
-			<version>${java-lib-version}</version>
-			<outputFileNameMapping>crypto-java-lib.jar</outputFileNameMapping>
+			<version>${crypto.java.lib.version}</version>
+			<outputFileNameMapping>crypto-java-lib-${crypto.java.lib.version}.jar</outputFileNameMapping>
 		</dependencySet>
 	</dependencySets>
 </package>

--- a/xquery-license-style.xml
+++ b/xquery-license-style.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<additionalHeaders>
+    <xquery_style>
+        <firstLine>(:</firstLine>
+        <beforeEachLine> : </beforeEachLine>
+        <endLine> :)</endLine>
+        <afterEachLine>EOL</afterEachLine>
+        <skipLine> </skipLine>
+        <firstLineDetectionPattern>"(\\s|\\t)*/\\*.*$"</firstLineDetectionPattern>
+        <lastLineDetectionPattern>".*\\*/(\\s|\\t)*$"</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </xquery_style>
+</additionalHeaders>


### PR DESCRIPTION
Apart from the general code cleanup, the changes when combined with the those for the Crypto Java lib should result in a reduction of 66% memory use for Hash and HMAC functions.

Instead of making various copies in-memory of binary data, we now operate directly on the binary streams provided by eXist-db.